### PR TITLE
cosmetic version syntax updates

### DIFF
--- a/python/crowdsource.py
+++ b/python/crowdsource.py
@@ -1011,7 +1011,7 @@ def compute_iso_fit(impsfstack, psfstack, weightstack, apcor, psfderiv):
                           psfderiv[1][i]*weightstack[i]])
         aa = aa.reshape(3, -1).T
         par[i, :] = numpy.linalg.lstsq(
-            aa, (impsfstack[i]*weightstack[i]).reshape(-1))[0]
+            aa, (impsfstack[i]*weightstack[i]).reshape(-1), rcond=None)[0]
     zeroflux = par[:, 0] == 0
     return (par[:, 0], 
             (1-zeroflux)*par[:, 1]/(par[:, 0]+zeroflux), 

--- a/python/decam_proc.py
+++ b/python/decam_proc.py
@@ -88,7 +88,7 @@ def read_data(imfn, ivarfn, dqfn, extname, badpixmask=None,
     return imdei, imdew, imded
 
 
-def process_image(imfn, ivarfn, dqfn, outfn=None, clobber=False,
+def process_image(imfn, ivarfn, dqfn, outfn=None, overwrite=False,
                   outdir=None, verbose=False, nproc=numpy.inf, resume=False,
                   outmodelfn=None, profile=False, maskdiffuse=True):
     if profile:
@@ -130,7 +130,7 @@ def process_image(imfn, ivarfn, dqfn, outfn=None, clobber=False,
     if outdir is not None:
         outfn = os.path.join(outdir, outfn)
     if not resume or not os.path.exists(outfn):
-        fits.writeto(outfn, None, prihdr, clobber=clobber)
+        fits.writeto(outfn, None, prihdr, overwrite=overwrite)
         extnamesdone = None
     else:
         hdulist = fits.open(outfn)
@@ -144,11 +144,11 @@ def process_image(imfn, ivarfn, dqfn, outfn=None, clobber=False,
             extnamesdone.append(ext)
         hdulist.close()
     if outmodelfn and (not resume or not os.path.exists(outmodelfn)):
-        fits.writeto(outmodelfn, None, prihdr, clobber=clobber)
+        fits.writeto(outmodelfn, None, prihdr, overwrite=overwrite)
     count = 0
     fwhms = []
     for name in extnames:
-        if name is 'PRIMARY':
+        if name == 'PRIMARY':
             continue
         hdr = fits.getheader(imfn, extname=name)
         if 'FWHM' in hdr:
@@ -156,7 +156,7 @@ def process_image(imfn, ivarfn, dqfn, outfn=None, clobber=False,
     fwhms = numpy.array(fwhms)
     fwhms = fwhms[fwhms > 0]
     for name in extnames:
-        if name is 'PRIMARY':
+        if name == 'PRIMARY':
             continue
         if extnamesdone is not None and name in extnamesdone:
             print('Skipping %s, extension %s; already done.' % (imfn, name))
@@ -218,7 +218,7 @@ def process_image(imfn, ivarfn, dqfn, outfn=None, clobber=False,
         else:
             ra = numpy.zeros(0, dtype='f8')
             dec = numpy.zeros(0, dtype='f8')
-        from matplotlib.mlab import rec_append_fields
+        from numpy.lib.recfunctions import rec_append_fields
         decapsid = numpy.zeros(len(cat), dtype='i8')
         decapsid[:] = (prihdr['EXPNUM']*2**32*2**7 +
                        hdr['CCDNUM']*2**32 +

--- a/python/psf.py
+++ b/python/psf.py
@@ -1062,7 +1062,7 @@ def fit_linear_static_wing(x, y, xcen, ycen, stamp, imstamp, modstamp,
     isig_cen = central_stamp(isig, censize=pixsz)
     residfitdict = {}
     nperpar = (order+1)*(order+2)/2
-    residguess = numpy.zeros(nperpar, dtype='f4')
+    residguess = numpy.zeros(int(nperpar), dtype='f4')
 
     for i in range(pixsz):
         for j in range(pixsz):


### PR DESCRIPTION
I think this just solves some simple syntax issues that throw warnings in modern python environments. Clobber --> overwrite, is --> ==, rcond behavior, and rec_append_fields appears to have moved from matplotlib.mlab to numpy.lib.recfunctions. Feel free to take or leave the updates if you prefer an older environment.